### PR TITLE
検索表示の高速化#20

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include SessionsHelper
+  require "benchmark"
 
   private
 

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -4,29 +4,23 @@ class ShopsController < ApplicationController
 
   def home
     @shops = Shop.search("home")
-    @shop_hash = Shop.latest_set(@shops)
   end
 
   def search
     @shops = Shop.search(post_params).paginate(page: params[:page], per_page: 20)
     find_set
     @shops = Shop.search("all").paginate(page: params[:page], per_page: 20) if @shops.empty?
-    @shop_hash = Shop.latest_set(@shops)
-    @tags = Tag.name_set(params[:post][:tag_ids]) if params[:post][:tag_ids]
   end
 
   def map
     @shops = Shop.search(post_params)
     find_set
     @shops = Shop.search("all") if @shops.empty?
-    @shop_hash = Shop.latest_set(@shops)
-    @tags = Tag.name_set(params[:post][:tag_ids]) if params[:post][:tag_ids]
   end
 
   def show
     @shop = Shop.find(params[:id])
     @posts = @shop.posts
-    @shop_point = Shop.point_set(@shop)
     @post = Post.new
   end
 
@@ -34,7 +28,6 @@ class ShopsController < ApplicationController
     @shop = Shop.find(params[:id])
     @posts = @shop.posts.paginate(page: params[:page], per_page: 3)
     redirect_to @shop if @posts.empty?
-    @shop_point = Shop.point_set(@shop)
     @post = Post.new
   end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,8 @@
 class Post < ApplicationRecord
   belongs_to :shop
   belongs_to :member
+  # belongs_to :latest_post, foreign_key: "latest_post_id", class_name: "Shop" 
+  # belongs_to :latest_img, foreign_key: "latest_img_id", class_name: "Shop" 
   validates :title, presence: true, length: { maximum: 50 }
   validates :comment, presence: true, length: { maximum: 3000 }
   validates :point, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 5 }

--- a/app/views/shared/_tagsform.html.erb
+++ b/app/views/shared/_tagsform.html.erb
@@ -1,7 +1,7 @@
 <div class='search_form_tags'>
   <% tag_count = 0 %>
   <% current_type = 0 %>
-  <%= object.collection_check_boxes(:tag_ids, Tag.all.order(type: :asc).order(id: :asc), :id, :name,include_hidden: false ) do |tag| %>
+  <%= object.collection_check_boxes("post[tag_ids]", Tag.all.order(type: :asc).order(id: :asc), :id, :name,include_hidden: false ) do |tag| %>
     <% if current_type != tag.object.type %>
       <% if current_type != 0 %>
         </div>

--- a/app/views/shops/_shop.html.erb
+++ b/app/views/shops/_shop.html.erb
@@ -7,8 +7,8 @@
   <%= link_to "", shop, class: :wrap %>
   <div class="shop_left">
     <div class="shop_image">
-      <% if @shop_hash[shop.id][:img] %>
-        <%= image_tag(@shop_hash[shop.id][:img]) %>
+      <% if shop.latest_img %>
+        <%= image_tag(shop.latest_img.images.first) %>
       <% else %>
         <img src="/images/no_image.png" alt="NoImage" />
       <% end %>
@@ -41,13 +41,13 @@
     <% if controller.action_name == "search" %>
       <div class="shop_right_topCom">
         <div class="shop_right_topCom_title">
-          <% if @shop_hash[shop.id][:dtl] %>
-            <%= @shop_hash[shop.id][:dtl].title %>
+          <% if shop.latest_post %>
+            <%= shop.latest_post.title %>
             <span class="shop_right_topCom_title_by">
-              by <%= link_to @shop_hash[shop.id][:dtl].member.name, postlist_member_path(@shop_hash[shop.id][:dtl].member) %> さん
+              by <%= link_to shop.latest_post.member.name, postlist_member_path(shop.latest_post.member) %> さん
             </span>
             <div class="shop_right_topCom_comment">
-              <%= @shop_hash[shop.id][:dtl].comment %>
+              <%= shop.latest_post.comment %>
             </div>
           <% else %>
             ※まだレビューがありません

--- a/app/views/shops/_shopHead.html.erb
+++ b/app/views/shops/_shopHead.html.erb
@@ -4,9 +4,9 @@
       <%= controller.action_name == "show" ? @shop.name : link_to(@shop.name, shop_path(@shop)) %>
     </div>
     <div class="shop_head_point">
-      <div class="raty" read_only="true" data_score="<%= @shop_point %>"></div>
+      <div class="raty" read_only="true" data_score="<%= @shop.point_avg %>"></div>
       <div class="shop_head_point_num">
-        <%= @shop_point %>
+        <%= @shop.point_avg %>
       </div>
     </div>
     <div class="shop_head_tag">

--- a/app/views/shops/home.html.erb
+++ b/app/views/shops/home.html.erb
@@ -10,8 +10,8 @@
           <%= link_to "", shop, class: :wrap %>
           <div class="home_left_review_shop_left">
             <div class="home_left_review_shop_left_img">
-              <% if @shop_hash[shop.id][:img] %>
-                <%= image_tag(@shop_hash[shop.id][:img]) %>
+              <% if shop.latest_img %>
+                <%= image_tag(shop.latest_img.images.first) %>
               <% else %>
                 <%= image_tag("/images/no_image.png") %>
               <% end %>

--- a/app/views/shops/map.html.erb
+++ b/app/views/shops/map.html.erb
@@ -12,14 +12,8 @@ const data = [
 let map
 
 function initMap(){
-  //デフォルトの緯度経度の変数
-  const latLng = {
-    lat: 35.729642,
-    lng: 139.710887
-  };
 
   map = new google.maps.Map(document.getElementById('map'), {
-    center: latLng,
     zoom: 15,
     gestureHandling: 'greedy',
   });

--- a/app/views/shops/search.html.erb
+++ b/app/views/shops/search.html.erb
@@ -29,6 +29,7 @@ $(document).on('turbolinks:load', function(){
 <% provide(:title, '店舗検索') %>
 <% breadcrumb :search %>
 <%= render partial: "result" %>
+<%= @result %>
 
 <%= will_paginate %>
 

--- a/db/migrate/20200904174132_create_shopstotals.rb
+++ b/db/migrate/20200904174132_create_shopstotals.rb
@@ -1,0 +1,12 @@
+class CreateShopstotals < ActiveRecord::Migration[6.0]
+  def change
+    create_table :shopstotals do |t|
+      t.references :shop, null: false, foreign_key: true
+      t.decimal :point_avg, precision: 2, scale: 1
+      t.references :latest_post_id, foreign_key: { to_table: :posts }
+      t.references :latest_img_id, foreign_key: { to_table: :posts }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200904195404_change_column_to_allow_null.rb
+++ b/db/migrate/20200904195404_change_column_to_allow_null.rb
@@ -1,0 +1,8 @@
+class ChangeColumnToAllowNull < ActiveRecord::Migration[6.0]
+  def change
+    change_table :shopstotals, bulk: true do |t|
+      t.column :latest_post_id, :bigint, foreign_key: { to_table: :posts }, null: true
+      t.column :latest_img_id, :bigint, foreign_key: { to_table: :posts }, null: true
+    end
+  end
+end

--- a/db/migrate/20200904201046_drop_shopstotals.rb
+++ b/db/migrate/20200904201046_drop_shopstotals.rb
@@ -1,0 +1,5 @@
+class DropShopstotals < ActiveRecord::Migration[6.0]
+  def change
+    drop_table :shopstotals
+  end
+end

--- a/db/migrate/20200904201801_re_create_shopstotal.rb
+++ b/db/migrate/20200904201801_re_create_shopstotal.rb
@@ -1,0 +1,12 @@
+class ReCreateShopstotal < ActiveRecord::Migration[6.0]
+  def change
+    create_table :shopstotals do |t|
+      t.references :shop, null: false, foreign_key: true
+      t.decimal :point_avg, precision: 2, scale: 1
+      t.references :latest_post, foreign_key: { to_table: :posts }, null: true
+      t.references :latest_img, foreign_key: { to_table: :posts }, null: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200905052611_re_drop_shopstotals.rb
+++ b/db/migrate/20200905052611_re_drop_shopstotals.rb
@@ -1,0 +1,5 @@
+class ReDropShopstotals < ActiveRecord::Migration[6.0]
+  def change
+    drop_table :shopstotals
+  end
+end

--- a/db/migrate/20200905052818_add_shop_to_totals.rb
+++ b/db/migrate/20200905052818_add_shop_to_totals.rb
@@ -1,0 +1,7 @@
+class AddShopToTotals < ActiveRecord::Migration[6.0]
+  def change
+    change_table :shops, bulk: true do |t|
+      t.column :point_avg, :decimal, precision: 2, scale: 1
+    end
+  end
+end

--- a/db/migrate/20200905063146_add_shop_to_totals_id.rb
+++ b/db/migrate/20200905063146_add_shop_to_totals_id.rb
@@ -1,0 +1,6 @@
+class AddShopToTotalsId < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :shops, :latest_post, foreign_key: { to_table: :posts }, null: true
+    add_reference :shops, :latest_img, foreign_key: { to_table: :posts }, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_26_120834) do
+ActiveRecord::Schema.define(version: 2020_09_05_063146) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -81,6 +81,11 @@ ActiveRecord::Schema.define(version: 2020_08_26_120834) do
     t.datetime "updated_at", precision: 6, null: false
     t.float "latitude", limit: 53
     t.float "longitude", limit: 53
+    t.decimal "point_avg", precision: 2, scale: 1
+    t.bigint "latest_post_id"
+    t.bigint "latest_img_id"
+    t.index ["latest_img_id"], name: "index_shops_on_latest_img_id"
+    t.index ["latest_post_id"], name: "index_shops_on_latest_post_id"
     t.index ["member_id"], name: "index_shops_on_member_id"
   end
 
@@ -96,4 +101,6 @@ ActiveRecord::Schema.define(version: 2020_08_26_120834) do
   add_foreign_key "posts", "shops"
   add_foreign_key "shop_tag_relations", "shops"
   add_foreign_key "shop_tag_relations", "tags"
+  add_foreign_key "shops", "posts", column: "latest_img_id"
+  add_foreign_key "shops", "posts", column: "latest_post_id"
 end

--- a/spec/factories/shopstotals.rb
+++ b/spec/factories/shopstotals.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :shopstotal do
+    shop { nil }
+    point_avg { "9.99" }
+    latest_post_id { 1 }
+    latest_img_id { 1 }
+  end
+end

--- a/spec/models/shopstotal_spec.rb
+++ b/spec/models/shopstotal_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Shopstotal, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
正規化レベルが下がるため、集計テーブルの作成はせずに、既存のShopsテーブルに集計カラムを追加。
0.3〜0.4sほど処理を高速化。